### PR TITLE
Add query, query_first overloads for callable model argument

### DIFF
--- a/pydapper/commands.py
+++ b/pydapper/commands.py
@@ -193,6 +193,12 @@ class Commands(BaseCommands, ABC):
 
     @overload
     def query(
+        self, sql: str, param: Optional["ParamType"] = ..., buffered: "Literal[True]" = True, *, model: Callable[..., "_T"]
+    ) -> List["_T"]:
+        ...
+    
+    @overload
+    def query(
         self, sql: str, param: Optional["ParamType"] = ..., *, model: Type["_T"], buffered: "Literal[False]"
     ) -> Generator["_T", None, None]:
         ...
@@ -238,6 +244,10 @@ class Commands(BaseCommands, ABC):
 
     @overload
     def query_first(self, sql: str, param: Optional["ParamType"] = ..., *, model: Type["_T"]) -> "_T":
+        ...
+
+    @overload
+    def query_first(self, sql: str, param: Optional["ParamType"] = ..., *, model: Callable[..., "_T"]) -> "_T":
         ...
 
     def query_first(self, sql, model=dict, param=None):


### PR DESCRIPTION
The `model` argument of `Commands.query` and `Commands.query_first` could also be a callable function instead of a type, but type checkers mark this as a type error. This PR adds overloads in order to satisfy type checkers in such cases.